### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: required
 
 matrix:
   include:
-    - php: 7.4snapshot
+    - php: 7.4
     - php: 7.3
     - php: 7.2
     - php: 7.1
@@ -28,7 +28,7 @@ install:
 
 before_script:
   - travis_retry composer self-update
-  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --no-interaction --prefer-source --dev
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install --no-interaction --prefer-source
 
 script:
   - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.xml

--- a/tests/ComposerPluginTest.php
+++ b/tests/ComposerPluginTest.php
@@ -18,13 +18,13 @@ class ComposerPluginTest extends TestCase
         $plugin = new ComposerPlugin();
         $plugin->activate($composer, $io);
         $events = ComposerPlugin::getSubscribedEvents();
-        $this->assertTrue(is_array($events));
-        $this->assertTrue(is_array($events['post-autoload-dump']));
-        $this->assertTrue(is_array($events['post-autoload-dump'][0]));
+        $this->assertInternalType('array', $events);
+        $this->assertInternalType('array', $events['post-autoload-dump']);
+        $this->assertInternalType('array', $events['post-autoload-dump'][0]);
         $method = $events['post-autoload-dump'][0][0];
         $plugin->$method($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
         static::removeTestDirectories();
     }
 }

--- a/tests/NodejsPhpFallbackTest.php
+++ b/tests/NodejsPhpFallbackTest.php
@@ -45,7 +45,7 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertSame(realpath(static::appDirectory()), NodejsPhpFallback::getPrefixPath());
         $this->assertSame(realpath(static::appDirectory() . '/node_modules'), NodejsPhpFallback::getNodeModules());
         $this->assertSame(realpath(static::appDirectory() . '/node_modules/stylus'), NodejsPhpFallback::getNodeModule('stylus'));
@@ -67,8 +67,8 @@ class NodejsPhpFallbackTest extends TestCase
 
         $this->assertSame('Packages installed.', $io->getLastOutput());
         $this->assertFalse($io->isErrored());
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -98,8 +98,8 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -113,8 +113,8 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -129,8 +129,8 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -145,9 +145,9 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertFalse(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryNotExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertFalse(NodejsPhpFallback::isInstalledPackage('stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('pug-cli'));
         static::removeTestDirectories();
     }
@@ -164,9 +164,9 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('pug-cli'));
         static::removeTestDirectories();
 
@@ -180,9 +180,9 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('pug-cli'));
         static::removeTestDirectories();
 
@@ -198,9 +198,9 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertFalse(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryNotExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertFalse(NodejsPhpFallback::isInstalledPackage('stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('pug-cli'));
         static::removeTestDirectories();
 
@@ -214,9 +214,9 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertFalse(is_dir(static::appDirectory() . '/node_modules/stylus'));
+        $this->assertDirectoryNotExists(static::appDirectory() . '/node_modules/stylus');
         $this->assertFalse(NodejsPhpFallback::isInstalledPackage('stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         $this->assertTrue(NodejsPhpFallback::isInstalledPackage('pug-cli'));
         static::removeTestDirectories();
     }
@@ -230,8 +230,8 @@ class NodejsPhpFallbackTest extends TestCase
             'pug-cli' => '*',
         ));
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -251,8 +251,8 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertFalse(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryNotExists(static::appDirectory() . '/node_modules/pug-cli');
         static::removeTestDirectories();
     }
 
@@ -265,8 +265,8 @@ class NodejsPhpFallbackTest extends TestCase
         $event = new Event('install', $composer, $io);
         NodejsPhpFallback::install($event);
 
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/stylus'));
-        $this->assertTrue(is_dir(static::appDirectory() . '/node_modules/pug-cli'));
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/stylus');
+        $this->assertDirectoryExists(static::appDirectory() . '/node_modules/pug-cli');
     }
 
     /**

--- a/tests/WrapperTest.php
+++ b/tests/WrapperTest.php
@@ -48,7 +48,7 @@ class NodejsPhpFallbackTest extends TestCase
         static::removeDirectory(__DIR__ . '/../node_modules');
 
         $this->assertSame(42, $withFallback);
-        $this->assertSame(null, $withoutFallback);
+        $this->assertNull($withoutFallback);
     }
 
     public function testGetPath()

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -5,9 +5,9 @@ namespace NodejsPhpFallbackTest;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Package\RootPackage;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends PHPUnitTestCase
 {
     protected static $deleteAfterTest = array();
 


### PR DESCRIPTION
# Changed log
- The `php-7.4` version is available on Travis CI build environment, using the `php-7.4` instead.
- To be compatible with latest PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace instead.
- Using the `assertInternalType` to assert the type is same as `array`.
- Using the `assertDirectoryExists` and `assertDirectoryNotExists` to assert the specific directory is existed or non-existed.
- Using the `assertNull` to assert the result value is `null`.
- Remove `--dev` option during `composer install` command because this option is deprecated.
The deprecated message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```