### PR TITLE
Let php-nightly be failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
     - php: nightly
     - php: 7.4
     - php: 7.3
+  allow_failures:
+    - php: nightly
 
 env:
   global:


### PR DESCRIPTION
# Changed log
- Let `php-nightly` version can be failure during Travis CI build.
Nobody can guarantee that the unstable `PHP` version test can be always successful.