### PR TITLE
Add PSR-4 autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "codeclimate/php-test-reporter": "dev-master"
     },
     "autoload": {
-        "psr-0": {
-            "NodejsPhpFallback\\": "src/"
+        "psr-4": {
+            "NodejsPhpFallback\\": "src/NodejsPhpFallback/"
         }
     },
     "scripts": {


### PR DESCRIPTION
# Changed log
- The `PSR-0` is deprecated by `PHP-FIG` team, and using the `PSR-4` autloading instead.