### PR TITLE
Using cc-test-reporter script instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   global:
     - COMPOSER_FLAGS=''
     - TRAVIS_NODE_VERSION="7"
+    - CC_TEST_REPORTER_ID=06b079e57ae87f3c0d08c6cc73fbdf0a0204efa5325947ab6e8bcb30d7fcbb69
 
 install:
   - if [[ $TRAVIS_PHP_VERSION =~ ^nightly ]]; then COMPOSER_FLAGS='--ignore-platform-reqs'; fi
@@ -21,6 +22,9 @@ install:
   - npm install
 
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - travis_retry composer self-update
   - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer install ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
@@ -28,11 +32,7 @@ script:
   - vendor/bin/phpunit --verbose --coverage-text --coverage-clover=coverage.xml
 
 after_script:
-  - vendor/bin/test-reporter --coverage-report coverage.xml
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-addons:
-  code_climate:
-    repo_token: 06b079e57ae87f3c0d08c6cc73fbdf0a0204efa5325947ab6e8bcb30d7fcbb69

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     },
     "require-dev": {
         "composer/composer": "^1.2",
-        "phpunit/phpunit": "^8.5",
-        "codeclimate/php-test-reporter": "dev-master"
+        "phpunit/phpunit": "^8.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Changed log
- The `codeclimate/php-test-reporter` package is deprecated. Using the `test-reporter` script instead.